### PR TITLE
Fix(workaround really) the bogus addition of user-agent: 

### DIFF
--- a/rp/reverse_proxy.go
+++ b/rp/reverse_proxy.go
@@ -29,6 +29,12 @@ func GetRoutes() []config.Route {
 func setDestination(req *http.Request, url *url.URL) {
 	req.URL.Scheme = url.Scheme
 	req.URL.Host = url.Host
+	// Horrible hack to workaround golang behavior with User-Agent: addition
+	// same "fix" as https://github.com/golang/go/commit/6a6c1d9841a1957a2fd292df776ea920ae38ea00
+	if _, ok := req.Header["User-Agent"]; !ok {
+		// explicitly disable User-Agent so it's not set to default value
+		req.Header.Set("User-Agent", "")
+	}
 }
 
 // Director is the object used by the ReverseProxy to pick the route/destination.


### PR DESCRIPTION
by go client lib when none is set in a proxy context

fixes #15

before:

```
make dev # in proxy
go run . curl -loglevel debug -H user-agent: -H foo:bar localhost:8001/debug  # in Fortio with Fortio server running
[...]
User-Agent: Go-http-client/1.1
X-Forwarded-For: 127.0.0.1
```
after
```
go run . curl -loglevel debug -H user-agent: -H foo:bar localhost:8001/debug 
[...]
headers:

Host: localhost:8001
Accept-Encoding: gzip
Foo: bar
X-Forwarded-For: 127.0.0.1
```