### PR TITLE
support gzip for debug 

### DIFF
--- a/proxy_main.go
+++ b/proxy_main.go
@@ -66,7 +66,7 @@ func usage(msg string) {
 	os.Exit(1)
 }
 
-func DebugOnHostFunc(normalHandler http.HandlerFunc) http.HandlerFunc {
+func DebugOnHostHandler(normalHandler http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		debugHost := debugHost.Get()
 		if debugHost != "" && r.Host == debugHost {
@@ -101,7 +101,7 @@ func main() {
 		var a net.Addr
 		if debugHost != "" {
 			// Special case for debug host, redirect to https but also serve debug on that host
-			a = fhttp.HTTPServerWithHandler("https redirector + debug", *redirect, DebugOnHostFunc(fhttp.RedirectToHTTPSHandler))
+			a = fhttp.HTTPServerWithHandler("https redirector + debug", *redirect, DebugOnHostHandler(fhttp.RedirectToHTTPSHandler))
 		} else {
 			// Standard redirector without special debug host case
 			a = fhttp.RedirectToHTTPS(*redirect)
@@ -115,7 +115,7 @@ func main() {
 	hdlr = rp.ReverseProxy()
 	if debugHost != "" {
 		log.Warnf("Running Debug echo handler for any request matching Host %q", debugHost)
-		hdlr = http.HandlerFunc(DebugOnHostFunc(hdlr.ServeHTTP)) // that's the reverse proxy + debug handler
+		hdlr = DebugOnHostHandler(hdlr.ServeHTTP) // that's the reverse proxy + debug handler
 	}
 
 	s := &http.Server{

--- a/proxy_main.go
+++ b/proxy_main.go
@@ -70,7 +70,7 @@ func DebugOnHostFunc(normalHandler http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		debugHost := debugHost.Get()
 		if debugHost != "" && r.Host == debugHost {
-			rp.SafeDebugHandler(w, r)
+			rp.GzipDebugHandler.ServeHTTP(w, r)
 		} else {
 			normalHandler(w, r)
 		}
@@ -101,9 +101,7 @@ func main() {
 		var a net.Addr
 		if debugHost != "" {
 			// Special case for debug host, redirect to https but also serve debug on that host
-			var m *http.ServeMux
-			m, a = fhttp.HTTPServer("https redirector + debug", *redirect)
-			m.HandleFunc("/", DebugOnHostFunc(fhttp.RedirectToHTTPSHandler))
+			a = fhttp.HTTPServerWithHandler("https redirector + debug", *redirect, DebugOnHostFunc(fhttp.RedirectToHTTPSHandler))
 		} else {
 			// Standard redirector without special debug host case
 			a = fhttp.RedirectToHTTPS(*redirect)
@@ -117,10 +115,7 @@ func main() {
 	hdlr = rp.ReverseProxy()
 	if debugHost != "" {
 		log.Warnf("Running Debug echo handler for any request matching Host %q", debugHost)
-		// seems there should be a way to do this without the extra mux?
-		mux := http.NewServeMux()
-		mux.HandleFunc("/", DebugOnHostFunc(hdlr.ServeHTTP))
-		hdlr = mux // that's the reverse proxy + debug handler
+		hdlr = http.HandlerFunc(DebugOnHostFunc(hdlr.ServeHTTP)) // that's the reverse proxy + debug handler
 	}
 
 	s := &http.Server{

--- a/rp/reverse_proxy.go
+++ b/rp/reverse_proxy.go
@@ -89,6 +89,9 @@ func ReverseProxy() *httputil.ReverseProxy {
 	return &revp
 }
 
+// GzipDebugHandler is a handler wrapping SafeDebugHandler with optional gzip compression.
+var GzipDebugHandler = fhttp.Gzip(http.HandlerFunc(SafeDebugHandler))
+
 // DebugHandler is similar to Fortio's DebugHandler,
 // it returns debug/useful info to http client.
 // but doesn't have some of the extra sensitive info like env dump


### PR DESCRIPTION
also simplify the code using http.HandlerFunc to convert to handlers instead of needing a full mux

(manual) test, pending testcript tests
```
make dev

curl -v -H Accept-Encoding:gzip -H "Host: debug.fortio.org" http://localhost:8001/debug | gunzip

curl -v -H Accept-Encoding:gzip -H "Host: debug.fortio.org" http://localhost:8000/debug | gunzip
# and without host that it still redirects/forwards, respectively
```