### PR TITLE
add optional hostid flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,5 +30,5 @@ dev-h2c:
 dev:
 	# Run: curl -H "Host: debug.fortio.org" http://localhost:8001/debug
 	# and curl -H "Host: debug.fortio.org" http://localhost:8000/foo
-	go run -race . -http-port 8001 -https-port disabled -redirect-port 8000 \
+	go run -race . -http-port 8001 -https-port disabled -redirect-port 8000 -hostid "$(shell hostname)-test" \
 		-debug-host "debug.fortio.org" -routes.json '[{"host":"*", "destination":"http://localhost:8080/"}]'

--- a/proxy_main.go
+++ b/proxy_main.go
@@ -93,7 +93,7 @@ func main() {
 			log.Critf("Unable to watch config/flag changes in %v: %v", *configDir, err)
 		}
 	}
-	log.Printf("Fortio Proxy %s starting", longV)
+	log.Printf("Fortio Proxy %s starting - hostid %q", longV, rp.HostID.Get())
 	// Only turns on debug host if configured at launch,
 	// can be turned off or changed later through dynamic flags but not turned on if starting off
 	debugHost := debugHost.Get()

--- a/rp/reverse_proxy.go
+++ b/rp/reverse_proxy.go
@@ -24,6 +24,7 @@ import (
 var (
 	configs   = dflag.DynJSON(flag.CommandLine, "routes.json", &[]config.Route{}, "json list of `routes`")
 	h2Target  = flag.Bool("h2", false, "Whether destinations support h2c prior knowledge")
+	HostID    = dflag.DynString(flag.CommandLine, "hostid", "", "host id to show in debug-host output")
 	startTime = time.Now()
 )
 
@@ -102,9 +103,15 @@ func SafeDebugHandler(w http.ResponseWriter, r *http.Request) {
 	var buf bytes.Buffer
 	buf.WriteString("Φορτίο version ")
 	buf.WriteString(version.Long())
-	buf.WriteString(" echo debug server up for ")
+	buf.WriteString("\nDebug server")
+	id := HostID.Get()
+	if id != "" {
+		buf.WriteString(" on ")
+		buf.WriteString(id)
+	}
+	buf.WriteString(" up for ")
 	buf.WriteString(fmt.Sprint(fhttp.RoundDuration(time.Since(startTime))))
-	buf.WriteString(" - request from ")
+	buf.WriteString("\nRequest from ")
 	buf.WriteString(r.RemoteAddr)
 	buf.WriteString(fhttp.TLSInfo(r))
 	buf.WriteString("\n\n")


### PR DESCRIPTION
So different hosts can be identified, if desired

output:

```
Φορτίο version 1.40.0 h1:jSDO/jGcyC/qTpMZZ84EZbn9BQawsWM9/RMQ9s6Cn3w= go1.19.5 arm64 darwin (in fortio.org/proxy dev)
Debug server on xxx-test up for 200ms
Request from 127.0.0.1:56966

GET /debug HTTP/1.1

headers:

Host: debug.fortio.org
Accept: */*
User-Agent: curl/7.79.1

body:

```