### PR TITLE
remove/update goreleaser deprecated `replacements:` and others

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -33,6 +33,6 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,11 +9,13 @@ builds:
       - amd64
       - arm64
 archives:
-  - replacements:
-      darwin: Mac
-      linux: Linux
-      windows: Windows
-      amd64: x86_64
+  - id: binaries
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
 checksum:
   name_template: "checksums.txt"
 snapshot:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -58,7 +58,7 @@ release:
 brews:
   -
     # GitHub/GitLab repository to push the formula to
-    tap:
+    repository:
       owner: fortio
       name: homebrew-tap
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,14 +8,6 @@ builds:
     goarch:
       - amd64
       - arm64
-archives:
-  - id: binaries
-    name_template: >-
-      {{ .ProjectName }}_
-      {{- title .Os }}_
-      {{- if eq .Arch "amd64" }}x86_64
-      {{- else if eq .Arch "386" }}i386
-      {{- else }}{{ .Arch }}{{ end }}
 checksum:
   name_template: "checksums.txt"
 snapshot:


### PR DESCRIPTION
fix #117

downside: names will now be darwin instead of mac, amd64 instead of x86_64 etc
