### PR TITLE
New `-tailscale` flag to automatically use the server's .ts.net name in cert domains

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,11 @@ dev-h2c:
 		-debug-host "debug.fortio.org" \
 		 -default-route http://localhost:8080/
 
+# Not needed anymore outside of debughost, -tailscale does this for us
 TAILSCALE_SERVERNAME=$(shell tailscale status --json | jq -r '.Self.DNSName | sub("\\.$$"; "")')
 dev-tailscale:
 	@echo "Visit https://$(TAILSCALE_SERVERNAME)/"
-	go run -race . -loglevel debug -hostid local -certs-domains $(TAILSCALE_SERVERNAME) -debug-host $(TAILSCALE_SERVERNAME)
+	go run -race . -loglevel debug -hostid local -tailscale -debug-host $(TAILSCALE_SERVERNAME)
 
 dev:
 	# Run: curl -H "Host: debug.fortio.org" http://localhost:8001/debug

--- a/README.md
+++ b/README.md
@@ -65,3 +65,8 @@ If you want to setup TLS and forward everything to local (h2c) http server runni
 go run fortio.org/proxy@latest -certs-domains ...your..server..full..name -h2 -default-route localhost:3000
 ```
 (`http://` prefix can be omitted in the default route only)
+
+You can get full help/flags using
+```sh
+proxy help
+```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Fortio simple TLS/ingress autocert proxy
 
 Front end for running fortio report for instance standalone with TLS / Autocert and routing rules to multiplex multiple service behind a common TLS ingress (works with and allows multiplexing of grpc and h2c servers too)
 
-Any -certs-domains ending with `.ts.net` will be handled by the Tailscale cert client (see https://tailscale.com/kb/1153/enabling-https).
+Any -certs-domains ending with `.ts.net` will be handled by the Tailscale cert client (see https://tailscale.com/kb/1153/enabling-https). Or you can now specify `-tailscale` and it will get the local server name and domain automatically using the tailscale go client api.
 
 # Install
 

--- a/config/no_tailscale.go
+++ b/config/no_tailscale.go
@@ -12,3 +12,7 @@ func IsTailscale(_ string) bool {
 func Tailscale() CertificateProvider {
 	return nil
 }
+
+func TailscaleServerName() string {
+	return ""
+}

--- a/config/no_tailscale.go
+++ b/config/no_tailscale.go
@@ -14,5 +14,5 @@ func Tailscale() CertificateProvider {
 }
 
 func TailscaleServerName() string {
-	return ""
+	panic("Binary built without tailscale support, rebuild without -tags no_tailscale")
 }

--- a/config/tailscale.go
+++ b/config/tailscale.go
@@ -32,7 +32,7 @@ func Tailscale() CertificateProvider {
 }
 
 func TailscaleServerName() string {
-	status, err := tcli.Status(context.Background())
+	status, err := tcli.StatusWithoutPeers(context.Background())
 	if err != nil {
 		log.Critf("Error getting tailscale status: %v", err)
 		return ""

--- a/proxy_main.go
+++ b/proxy_main.go
@@ -34,11 +34,16 @@ var (
 	port           = flag.String("https-port", ":443", "`port` to listen on for main reverse proxy and tls traffic")
 	redirect       = flag.String("redirect-port", ":80", "`port` to listen on for redirection")
 	httpPort       = flag.String("http-port", "disabled", "`port` to listen on for non tls traffic (or 'disabled')")
+	autoTailscale  = flag.Bool("auto-tailscale", true, "Automatically add tailscale hostname to the certificate list")
 	acert          *autocert.Manager
+	tailscale      string
 )
 
 func hostPolicy(_ context.Context, host string) error {
 	log.LogVf("cert host policy called for %q", host)
+	if host == tailscale {
+		return nil
+	}
 	allowed := certsFor.Get()
 	if _, found := allowed[host]; found {
 		return nil
@@ -78,6 +83,10 @@ func main() {
 		if a == nil {
 			os.Exit(1) // Error already logged
 		}
+	}
+	if *autoTailscale {
+		tailscale = config.TailscaleServerName()
+		log.Infof("Will accept TLS requests and obtain certificate for tailscale server name %q", tailscale)
 	}
 	// Main reverse proxy handler (with debug if configured)
 	var hdlr http.Handler

--- a/proxy_main.go
+++ b/proxy_main.go
@@ -34,7 +34,7 @@ var (
 	port           = flag.String("https-port", ":443", "`port` to listen on for main reverse proxy and tls traffic")
 	redirect       = flag.String("redirect-port", ":80", "`port` to listen on for redirection")
 	httpPort       = flag.String("http-port", "disabled", "`port` to listen on for non tls traffic (or 'disabled')")
-	autoTailscale  = flag.Bool("auto-tailscale", true, "Automatically add tailscale hostname to the certificate list")
+	autoTailscale  = flag.Bool("tailscale", true, "Automatically add tailscale hostname to the certificate list")
 	acert          *autocert.Manager
 	tailscale      string
 )
@@ -86,7 +86,7 @@ func main() {
 	}
 	if *autoTailscale {
 		tailscale = config.TailscaleServerName()
-		log.Infof("Will accept TLS requests and obtain certificate for tailscale server name %q", tailscale)
+		log.S(log.Info, "Will accept TLS requests and obtain certificate for tailscale", log.Any("server-name", tailscale))
 	}
 	// Main reverse proxy handler (with debug if configured)
 	var hdlr http.Handler

--- a/proxy_main.go
+++ b/proxy_main.go
@@ -34,7 +34,7 @@ var (
 	port           = flag.String("https-port", ":443", "`port` to listen on for main reverse proxy and tls traffic")
 	redirect       = flag.String("redirect-port", ":80", "`port` to listen on for redirection")
 	httpPort       = flag.String("http-port", "disabled", "`port` to listen on for non tls traffic (or 'disabled')")
-	autoTailscale  = flag.Bool("tailscale", true, "Automatically add tailscale hostname to the certificate list")
+	autoTailscale  = flag.Bool("tailscale", false, "Automatically add tailscale hostname to the certificate list")
 	acert          *autocert.Manager
 	tailscale      string
 )

--- a/proxy_main.go
+++ b/proxy_main.go
@@ -41,7 +41,7 @@ var (
 
 func hostPolicy(_ context.Context, host string) error {
 	log.LogVf("cert host policy called for %q", host)
-	if host == tailscale {
+	if tailscale != "" && host == tailscale {
 		return nil
 	}
 	allowed := certsFor.Get()
@@ -86,6 +86,9 @@ func main() {
 	}
 	if *autoTailscale {
 		tailscale = config.TailscaleServerName()
+		if tailscale == "" {
+			os.Exit(1) // Error already logged
+		}
 		log.S(log.Info, "Will accept TLS requests and obtain certificate for tailscale", log.Any("server-name", tailscale))
 	}
 	// Main reverse proxy handler (with debug if configured)


### PR DESCRIPTION
- [x] feature (auto) `-tailscale`
- [x] doc