### PR TITLE
Configurable `-timeout` and increased default to 1 minute (from 6 seconds)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,5 @@ You can get full help/flags using
 ```sh
 proxy help
 ```
+
+Use `-timeout 0` or a high value like `1h` if you're going to use it to download/upload large models or otherwise slow transactions. The default is 1 minute maximum.

--- a/proxy_main.go
+++ b/proxy_main.go
@@ -35,7 +35,7 @@ var (
 	redirect       = flag.String("redirect-port", ":80", "`port` to listen on for redirection")
 	httpPort       = flag.String("http-port", "disabled", "`port` to listen on for non tls traffic (or 'disabled')")
 	autoTailscale  = flag.Bool("tailscale", false, "Automatically add tailscale hostname to the certificate list")
-	timeout        = flag.Duration("timeout", 15*time.Second,
+	timeout        = flag.Duration("timeout", 1*time.Minute,
 		"Maximum duration for each request read/writes proxying (eg 1h or use 0 for no timeout)")
 	acert     *autocert.Manager
 	tailscale string


### PR DESCRIPTION
Fixes #280 